### PR TITLE
Add Outputs for WinAdmins Server Data URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # DuckBot3
 Build Status: [![Build Status](https://dev.azure.com/duckbot3/duckbot3/_apis/build/status/windows-admins.duckbot?branchName=main)](https://dev.azure.com/duckbot3/duckbot3/_build/latest?definitionId=1&branchName=main)
+ 

--- a/deploy.json
+++ b/deploy.json
@@ -162,5 +162,22 @@
              "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', concat(concat(parameters('deploymentName'),'discord'), uniqueString(resourceGroup().id)) )]"
          }
     }
-    ]
+    ],
+    "outputs": {
+        "apiEndpoints": {
+            "type": "array",
+            "value": [
+                {
+                    "comments": "Might be able to use a function, enumerate DUCKBOT_STORAGEACCOUNT_NAME or DUCKBOT_STORAGEACCOUNT_POINTTABLE and get a list of 'guilds' to build a list for all or each tenant, currently these statically query WinAdmins",
+                    "name": "TopMembers",
+                    "value": "[uri(resourceId('Microsoft.Web/sites',concat(concat(parameters('deploymentName'),'discord'), uniqueString(resourceGroup().id))),'guild/618712310185197588/members')]"
+                },
+                {
+                    "comments": "Might be able to use a function, enumerate DUCKBOT_STORAGEACCOUNT_NAME or DUCKBOT_STORAGEACCOUNT_POINTTABLE and get a list of 'guilds' to build a list for all or each tenant, currently these statically query WinAdmins",
+                    "name": "TopThings",
+                    "value": "[uri(resourceId('Microsoft.Web/sites',concat(concat(parameters('deploymentName'),'discord'), uniqueString(resourceGroup().id))),'guild/618712310185197588/members')]"
+                }
+            ]
+        }
+    }
   }


### PR DESCRIPTION
Tried adding outputs from the Deploy.json / Deploy pipeline to provide URLs for WinAdmins status pages

I didn't show any syntax errors in VSCode - but can't test with the live environment, so if this breaks it might need a rollback
